### PR TITLE
Add initial Jekyll docs site with remote theme

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3"
+
+group :jekyll_plugins do
+  gem "jekyll-remote-theme"
+end
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-﻿# Oxi Docs
+# OXI Docs
+
+## Local dev
+bundle install
+bundle exec jekyll serve
+
+## Deploy
+GitHub Pages -> Source: main (root)
+

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,4 @@
+title: OXI Documentation
+plugins:
+  - jekyll-remote-theme
+remote_theme: Anodyne-Technologies/anodyne-pages@v0.1.0

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -1,0 +1,5 @@
+nav:
+  primary:
+    - { title: "Manual", url: "/manual/" }
+    - { title: "Scripting API", url: "/api/" }
+    - { title: "Dev Logs", url: "/devlogs/" }

--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -1,0 +1,6 @@
+.hero { margin-block: 2rem; }
+.cta-row { display: flex; gap: 1rem; margin-top: 1rem; flex-wrap: wrap; }
+.btn { padding: .6rem 1rem; border-radius: .75rem; border: 1px solid currentColor; text-decoration: none; }
+.search { margin-block: 2rem; }
+#site-search { padding: .6rem .8rem; width: min(720px, 100%); }
+.getting-started { margin-block: 2rem; }

--- a/index.md
+++ b/index.md
@@ -1,0 +1,42 @@
+---
+layout: home
+title: OXI Documentation
+permalink: /
+---
+
+<section class="hero" aria-labelledby="hero-title">
+  <h1 id="hero-title">OXI Documentation</h1>
+  <p>Build XR with a clean, strongly-typed, path-based API. Unity-first integration, engine-agnostic core.</p>
+  <div class="cta-row">
+    <a class="btn" href="/manual/">Manual</a>
+    <a class="btn" href="/api/">Scripting API</a>
+    <a class="btn" href="/devlogs/">Dev Logs</a>
+  </div>
+</section>
+
+<section class="search" aria-labelledby="search-title">
+  <h2 id="search-title">Search</h2>
+  <input id="site-search" type="search" placeholder="Search docs…" aria-label="Search docs (press / to focus)" />
+  <p class="hint">Tip: press “/” to focus the search box.</p>
+</section>
+
+<section class="getting-started" aria-labelledby="gs-title">
+  <h2 id="gs-title">Getting Started</h2>
+  <ol>
+    <li><a href="/manual/overview/">What is OXI?</a></li>
+    <li><a href="/manual/installation/">Install &amp; Setup</a></li>
+    <li><a href="/manual/quickstart/">Quickstart</a></li>
+    <li><a href="/manual/unity/">Unity Integration</a></li>
+  </ol>
+</section>
+
+<script>
+window.addEventListener('keydown', function(event) {
+  if (event.key === '/' && document.activeElement !== document.getElementById('site-search')) {
+    event.preventDefault();
+    var search = document.getElementById('site-search');
+    if (search) { search.focus(); }
+  }
+});
+</script>
+


### PR DESCRIPTION
## Summary
- Configure Jekyll to use `Anodyne-Technologies/anodyne-pages@v0.1.0`
- Add landing page with navigation links and search placeholder
- Provide minimal CSS overrides and local dev instructions

## Testing
- `bundle install` *(fails: 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68a112969904832eb8379dcafbcdffba