### PR TITLE
fix: update remote theme configuration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
 title: OXI Documentation
 plugins:
   - jekyll-remote-theme
-remote_theme: Anodyne-Technologies/anodyne-pages@v0.1.0
+remote_theme: anodyne-technologies/anodyne-pages


### PR DESCRIPTION
## Summary
- remove pinned version from remote theme so builds can fetch the theme successfully

## Testing
- `bundle install` *(fails: 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: command not found: jekyll)*


------
https://chatgpt.com/codex/tasks/task_e_68a1149cb158832eb6488ad5cb56fd76