### PR TITLE
docs: document Unity pose pipeline and rig

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -1,5 +1,26 @@
-nav:
-  primary:
-    - { title: "Manual", url: "/manual/" }
-    - { title: "Scripting API", url: "/api/" }
-    - { title: "Dev Logs", url: "/devlogs/" }
+- title: Overview
+  url: /
+- title: Getting Started
+  children:
+    - title: Installation
+      url: /getting-started/installation/
+    - title: Quick Start (Unity Rig)
+      url: /getting-started/quick-start-rig/
+- title: Concepts
+  children:
+    - title: Data Pipeline (Providers & Receivers)
+      url: /concepts/data-pipeline/
+- title: Unity
+  children:
+    - title: Pose Pipeline (Input System)
+      url: /unity/pose-pipeline/
+    - title: OXI Rig
+      url: /unity/rig/
+    - title: Support Pack (Input, Prefab, Menu, Sample)
+      url: /unity/support-pack/
+- title: Guides
+  children:
+    - title: Submodules & Workspace
+      url: /guides/submodules/
+- title: Changelog
+  url: /changelog/

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,12 @@
+---
+layout: default
+title: Changelog
+nav_order: 99
+---
+
+## 0.0.1
+- Core: `IDataProvider<T>`, `IDataReceiver<T>`
+- Unity base: `BaseDataProvider<T>`, `BaseDataReceiver<T>`
+- Providers/Receivers: `InputActionPoseProvider`, `PoseReceiver`
+- Rig: `OXIRig`, `PoseWithOriginUtility`
+- Support Pack: Default Input Actions, Input References SO, Prefab, Editor Menu, Sample Scene

--- a/concepts/data-pipeline.md
+++ b/concepts/data-pipeline.md
@@ -1,0 +1,30 @@
+---
+layout: default
+title: Data Pipeline (Providers & Receivers)
+parent: Concepts
+nav_order: 1
+---
+
+## Contracts
+- `IDataProvider<T>`: `IsValid`, `Timestamp`, `TryGetValue(out T)`, `event OnValueChanged`.
+- `IDataReceiver<T>`: `SetProvider(IDataProvider<T>?)`.
+
+## Unity Base Classes
+- `BaseDataProvider<T>`: `RaiseValueChanged(T)`, timestamps via `Time.realtimeSinceStartupAsDouble`.
+- `BaseDataReceiver<T>`: safe subscribe/unsubscribe on enable/disable; inspector provider slot; pulls initial value on set.
+
+## Usage
+```csharp
+class FloatProvider : BaseDataProvider<float>
+{
+    public void Push(float v) => RaiseValueChanged(v);
+}
+
+class FloatReceiver : BaseDataReceiver<float>
+{
+    protected override void OnValueChanged(float v)
+    {
+        // apply value
+    }
+}
+```

--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -1,0 +1,30 @@
+---
+layout: default
+title: Installation
+parent: Getting Started
+nav_order: 1
+---
+
+## Requirements
+- Unity 6
+- `com.unity.inputsystem` (verified version)
+- Windows or Mac
+
+## Install OXI
+1. Add the package via Git URL or local path.
+2. Ensure your asmdef references `Unity.InputSystem`.
+
+## Enable Input System
+Project Settings → Player → Active Input Handling = **Input System** (or Both).
+
+## Package Manifest
+```json
+{
+  "dependencies": {
+    "com.unity.inputsystem": "1.10.0"
+  }
+}
+```
+
+## Verify
+Compile succeeds with no missing references.

--- a/getting-started/quick-start-rig.md
+++ b/getting-started/quick-start-rig.md
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Quick Start (Unity Rig)
+parent: Getting Started
+nav_order: 2
+---
+
+1. **Create Default Input Actions**
+   `Anodyne/OXI/Create/Import Default Input Actions` → configure HMD/Hands Pose actions.
+2. **Create Input References**
+   `Anodyne/OXI/Create/Create Input References` → assign the three Pose actions.
+3. **Create Rig Prefab**
+   `Anodyne/OXI/Create/OXI Rig Prefab` → open prefab and drag `OXI Input References` onto the providers if needed.
+4. **New Sample Scene**
+   `Anodyne/OXI/Create/Sample Scene (Rig)` → hit Play.
+5. **Expected**
+   Head/hand cubes follow device pose.

--- a/guides/submodules.md
+++ b/guides/submodules.md
@@ -1,0 +1,25 @@
+---
+layout: default
+title: Submodules & Workspace
+parent: Guides
+nav_order: 1
+---
+
+## Clone
+```sh
+git submodule update --init --recursive
+```
+
+## Pull latest (tracked branches)
+```sh
+git submodule update --remote --checkout --recursive
+```
+
+## Common fixes
+- `--checkout` vs `--merge`
+- Pin branches in `.gitmodules`
+- Reset a submodule
+- `git submodule update --init` to reinit
+
+## Workflow
+Keep submodules up to date before commits.

--- a/index.md
+++ b/index.md
@@ -1,42 +1,22 @@
 ---
-layout: home
-title: OXI Documentation
-permalink: /
+layout: default
+title: OXI — OpenXR Integrations (Unity-first)
+nav_order: 1
 ---
 
-<section class="hero" aria-labelledby="hero-title">
-  <h1 id="hero-title">OXI Documentation</h1>
-  <p>Build XR with a clean, strongly-typed, path-based API. Unity-first integration, engine-agnostic core.</p>
-  <div class="cta-row">
-    <a class="btn" href="/manual/">Manual</a>
-    <a class="btn" href="/api/">Scripting API</a>
-    <a class="btn" href="/devlogs/">Dev Logs</a>
-  </div>
-</section>
+## What is OXI?
+A lean XR toolkit for Unity that mirrors OpenXR’s logical structure while avoiding heavy management objects.
 
-<section class="search" aria-labelledby="search-title">
-  <h2 id="search-title">Search</h2>
-  <input id="site-search" type="search" placeholder="Search docs…" aria-label="Search docs (press / to focus)" />
-  <p class="hint">Tip: press “/” to focus the search box.</p>
-</section>
+## Core idea
+**Data Provider → Data Receiver** pipeline, strongly-typed and minimal.
 
-<section class="getting-started" aria-labelledby="gs-title">
-  <h2 id="gs-title">Getting Started</h2>
-  <ol>
-    <li><a href="/manual/overview/">What is OXI?</a></li>
-    <li><a href="/manual/installation/">Install &amp; Setup</a></li>
-    <li><a href="/manual/quickstart/">Quickstart</a></li>
-    <li><a href="/manual/unity/">Unity Integration</a></li>
-  </ol>
-</section>
+## Current status
+Unity-only pose pipeline & lightweight rig.
 
-<script>
-window.addEventListener('keydown', function(event) {
-  if (event.key === '/' && document.activeElement !== document.getElementById('site-search')) {
-    event.preventDefault();
-    var search = document.getElementById('site-search');
-    if (search) { search.focus(); }
-  }
-});
-</script>
-
+## Quick links
+- [Installation](/getting-started/installation/)
+- [Quick Start](/getting-started/quick-start-rig/)
+- [Pose Pipeline](/unity/pose-pipeline/)
+- [Rig](/unity/rig/)
+- [Support Pack](/unity/support-pack/)
+- [Changelog](/changelog/)

--- a/unity/pose-pipeline.md
+++ b/unity/pose-pipeline.md
@@ -1,0 +1,24 @@
+---
+layout: default
+title: Pose Pipeline (Input System)
+parent: Unity
+nav_order: 1
+---
+
+## Provider
+`InputActionPoseProvider` reads a single Pose action (preferred) or position+rotation actions. Actions auto-enable/disable and publish `Pose` on performed.
+
+## Receiver
+`PoseReceiver` applies poses to a `Transform` in World or Local space.
+
+## Inspector
+Assign `InputActionReference`s for HMD and hands. Actions should be **Pass Through** with control type **Pose**.
+
+## Bindings
+- HMD: `<XRHMD>/centerEyePose`
+- Left hand: `<XRController>{LeftHand}/devicePose`
+- Right hand: `<XRController>{RightHand}/devicePose`
+
+## Troubleshooting
+- No value? Ensure actions are Pass Through and device is plugged in.
+- Input System must be active in Project Settings.

--- a/unity/rig.md
+++ b/unity/rig.md
@@ -1,0 +1,21 @@
+---
+layout: default
+title: OXI Rig
+parent: Unity
+nav_order: 2
+---
+
+## What it does
+Centralizes wiring of providers to head/hand targets with optional origin offset.
+
+## Fields
+- `head`, `leftHand`, `rightHand`
+- `hmdPose`, `leftPose`, `rightPose`
+- `origin`
+- `applyOriginOffset`
+
+## Origin composition
+`PoseWithOriginUtility.Compose(origin, local)` aligns the rig to a play area.
+
+## Minimal scene graph
+Can live on one GameObject. Receivers are added automatically if missing.

--- a/unity/support-pack.md
+++ b/unity/support-pack.md
@@ -1,0 +1,25 @@
+---
+layout: default
+title: Support Pack (Input, Prefab, Menu, Sample)
+parent: Unity
+nav_order: 3
+---
+
+## Default Input Actions
+Asset contains HMD and hand pose actions with suggested bindings.
+
+## OXI Input References
+ScriptableObject storing references to the three pose actions.
+
+## OXIRig Prefab
+Prefab with head/hand cubes wired to pose providers.
+
+## Editor Menus
+`Anodyne/OXI/Create` offers:
+- Import Default Input Actions
+- Create Input References
+- OXI Rig Prefab
+- Sample Scene (Rig)
+
+## Sample Scene
+Basic scene that spawns the prefab for quick pose testing.


### PR DESCRIPTION
## Summary
- rewrite overview and navigation for Unity-first docs
- add guides for installation, quick-start rig, data pipeline, pose pipeline, rig, support pack, submodules, and changelog
- document providers and receivers for pose flow in Unity

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68a51dbaa284832eac2e779f36844a3e