### PR TITLE
Fix broken links on docs landing page

### DIFF
--- a/index.md
+++ b/index.md
@@ -14,9 +14,9 @@ A lean XR toolkit for Unity that mirrors OpenXR’s logical structure while avoi
 Unity-only pose pipeline & lightweight rig.
 
 ## Quick links
-- [Installation](/getting-started/installation/)
-- [Quick Start](/getting-started/quick-start-rig/)
-- [Pose Pipeline](/unity/pose-pipeline/)
-- [Rig](/unity/rig/)
-- [Support Pack](/unity/support-pack/)
-- [Changelog](/changelog/)
+- [Installation](getting-started/installation/)
+- [Quick Start](getting-started/quick-start-rig/)
+- [Pose Pipeline](unity/pose-pipeline/)
+- [Rig](unity/rig/)
+- [Support Pack](unity/support-pack/)
+- [Changelog](changelog/)


### PR DESCRIPTION
## Summary
- fix landing page links to respect repository base path

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a5e51da14c832ea4404aa648f0e55d