### PR TITLE
Docs: fix internal links to match actual output paths; use relative_url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,6 @@
 title: OXI Documentation
+url: "https://anodyne-technologies.github.io"
+baseurl: "/oxi-docs"
 plugins:
   - jekyll-remote-theme
 remote_theme: anodyne-technologies/anodyne-pages

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -3,24 +3,24 @@
 - title: Getting Started
   children:
     - title: Installation
-      url: /getting-started/installation/
+      url: /getting-started/installation.html
     - title: Quick Start (Unity Rig)
-      url: /getting-started/quick-start-rig/
+      url: /getting-started/quick-start-rig.html
 - title: Concepts
   children:
     - title: Data Pipeline (Providers & Receivers)
-      url: /concepts/data-pipeline/
+      url: /concepts/data-pipeline.html
 - title: Unity
   children:
     - title: Pose Pipeline (Input System)
-      url: /unity/pose-pipeline/
+      url: /unity/pose-pipeline.html
     - title: OXI Rig
-      url: /unity/rig/
+      url: /unity/rig.html
     - title: Support Pack (Input, Prefab, Menu, Sample)
-      url: /unity/support-pack/
+      url: /unity/support-pack.html
 - title: Guides
   children:
     - title: Submodules & Workspace
-      url: /guides/submodules/
+      url: /guides/submodules.html
 - title: Changelog
-  url: /changelog/
+  url: /changelog.html

--- a/index.md
+++ b/index.md
@@ -14,9 +14,9 @@ A lean XR toolkit for Unity that mirrors OpenXR’s logical structure while avoi
 Unity-only pose pipeline & lightweight rig.
 
 ## Quick links
-- [Installation](getting-started/installation/)
-- [Quick Start](getting-started/quick-start-rig/)
-- [Pose Pipeline](unity/pose-pipeline/)
-- [Rig](unity/rig/)
-- [Support Pack](unity/support-pack/)
-- [Changelog](changelog/)
+- [Installation]({{ '/getting-started/installation.html' | relative_url }})
+- [Quick Start]({{ '/getting-started/quick-start-rig.html' | relative_url }})
+- [Pose Pipeline]({{ '/unity/pose-pipeline.html' | relative_url }})
+- [Rig]({{ '/unity/rig.html' | relative_url }})
+- [Support Pack]({{ '/unity/support-pack.html' | relative_url }})
+- [Changelog]({{ '/changelog.html' | relative_url }})


### PR DESCRIPTION
## Summary
- configure site URL and base URL
- correct navigation links to target generated `.html` paths
- update home page quick links to use `relative_url`

## Testing
- ⚠️ `bundle install` (403 Forbidden)
- ⚠️ `JEKYLL_ENV=production jekyll build --baseurl "/oxi-docs"` (command not found)

------
https://chatgpt.com/codex/tasks/task_e_68a5f2aaa6f0832e913fffe79ae212c5